### PR TITLE
Fixed CIDGlyphs creations in case of Type0 fonts.

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/operator/textshow/GFOpTextShow.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/operator/textshow/GFOpTextShow.java
@@ -171,7 +171,8 @@ public abstract class GFOpTextShow extends GFOperator implements OpTextShow {
 							widthsConsistent = GFOpTextShow.checkWidths(code, font, fontProgram);
 						}
 						GFGlyph glyph;
-						if (font.getSubtype() == ASAtom.CID_FONT_TYPE0 || font.getSubtype() == ASAtom.CID_FONT_TYPE2) {
+						if (font.getSubtype() == ASAtom.CID_FONT_TYPE0 || font.getSubtype() == ASAtom.CID_FONT_TYPE2 ||
+								font.getSubtype() == ASAtom.TYPE0) {
 							int CID = ((PDType0Font) font).toCID(code);
 							glyph = new GFCIDGlyph(glyphPresent, widthsConsistent, font, code, CID,
 									this.renderingMode.getValue());


### PR DESCRIPTION
Closes https://github.com/veraPDF/veraPDF-library/issues/756.