### PR TITLE
Fixed groupCS link getter in PDPage, removed link to cs from PDGroup.

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/GFPDGroup.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/GFPDGroup.java
@@ -21,14 +21,7 @@
 package org.verapdf.gf.model.impl.pd;
 
 import org.verapdf.as.ASAtom;
-import org.verapdf.gf.model.factory.colors.ColorSpaceFactory;
-import org.verapdf.model.baselayer.Object;
-import org.verapdf.model.pdlayer.PDColorSpace;
 import org.verapdf.model.pdlayer.PDGroup;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * @author Maksim Bezrukov
@@ -36,8 +29,6 @@ import java.util.List;
 public class GFPDGroup extends GFPDObject implements PDGroup {
 
 	public static final String GROUP_TYPE = "PDGroup";
-
-	public static final String COLOR_SPACE = "colorSpace";
 
 	public GFPDGroup(org.verapdf.pd.PDGroup simplePDObject) {
 		super(simplePDObject, GROUP_TYPE);
@@ -49,23 +40,4 @@ public class GFPDGroup extends GFPDObject implements PDGroup {
 		return subtype == null ? null : subtype.getValue();
 	}
 
-	@Override
-	public List<? extends Object> getLinkedObjects(String link) {
-		if (COLOR_SPACE.equals(link)) {
-			return this.getColorSpace();
-		}
-		return super.getLinkedObjects(link);
-	}
-
-	private List<PDColorSpace> getColorSpace() {
-		org.verapdf.pd.colors.PDColorSpace pbColorSpace =
-				((org.verapdf.pd.PDGroup) this.simplePDObject).getColorSpace();
-		if (pbColorSpace != null) {
-			PDColorSpace colorSpace = ColorSpaceFactory.getColorSpace(pbColorSpace);
-			List<PDColorSpace> colorSpaces = new ArrayList<>(MAX_NUMBER_OF_ELEMENTS);
-			colorSpaces.add(colorSpace);
-			return Collections.unmodifiableList(colorSpaces);
-		}
-		return Collections.emptyList();
-	}
 }

--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/GFPDPage.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/GFPDPage.java
@@ -236,7 +236,10 @@ public class GFPDPage extends GFPDObject implements PDPage {
 	private List<PDColorSpace> getGroupCS() {
 		org.verapdf.pd.PDGroup group = ((org.verapdf.pd.PDPage) simplePDObject).getGroup();
 		if (group != null) {
-			org.verapdf.pd.colors.PDColorSpace colorSpace = group.getColorSpace();
+			org.verapdf.pd.PDPage page = (org.verapdf.pd.PDPage) this.simplePDObject;
+			PDResourcesHandler resourcesHandler = PDResourcesHandler.getInstance(page.getResources(),
+					page.isInheritedResources().booleanValue());
+			org.verapdf.pd.colors.PDColorSpace colorSpace = group.getColorSpace(resourcesHandler.getPageResources());
 			if (colorSpace != null) {
 				List<PDColorSpace> res = new ArrayList<>(MAX_NUMBER_OF_ELEMENTS);
 				// TODO: check this. Have we add resources here?


### PR DESCRIPTION
Needs https://github.com/veraPDF/veraPDF-parser/pull/252.
Closes https://github.com/veraPDF/veraPDF-model/issues/144.