### PR TITLE
Fix 984

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/GraphicState.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/GraphicState.java
@@ -39,6 +39,7 @@ public class GraphicState implements Cloneable {
 	private boolean overprintingFlagNonStroke = false;
 	private int opm = 0;
 	private GraphicState initialGraphicState = null;
+	private boolean processColorOperators = true;
 
 	private GraphicState() {
 	}
@@ -112,6 +113,15 @@ public class GraphicState implements Cloneable {
 		this.initialGraphicState = initialGraphicState.clone();
 	}
 
+	public boolean isProcessColorOperators() {
+		return processColorOperators;
+	}
+
+	public void disableColorOperators() {
+		this.processColorOperators = false;
+	}
+
+
 	public void copyProperties(GraphicState graphicState) {
 		this.fillColorSpace = graphicState.getFillColorSpace();
 		this.strokeColorSpace = graphicState.getStrokeColorSpace();
@@ -121,6 +131,7 @@ public class GraphicState implements Cloneable {
 		this.overprintingFlagNonStroke = graphicState.isOverprintingFlagNonStroke();
 		this.opm = graphicState.getOpm();
 		this.initialGraphicState = graphicState.getInitialGraphicState();
+		this.processColorOperators = graphicState.isProcessColorOperators();
 	}
 
 	public void copyPropertiesFormExtGState(PDExtGState extGState) {
@@ -152,6 +163,7 @@ public class GraphicState implements Cloneable {
 		clone.overprintingFlagNonStroke = this.overprintingFlagNonStroke;
 		clone.opm = this.opm;
 		clone.initialGraphicState = this.initialGraphicState;
+		clone.processColorOperators = this.processColorOperators;
 		return clone;
 	}
 

--- a/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/GraphicState.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/GraphicState.java
@@ -33,6 +33,8 @@ public class GraphicState implements Cloneable {
 
 	private PDColorSpace fillColorSpace;
 	private PDColorSpace strokeColorSpace;
+	private PDColorSpace fillLastPatternUnderlyingColorSpace = null;
+	private PDColorSpace strokeLastPatternUnderlyingColorSpace = null;
 	private RenderingMode renderingMode = RenderingMode.FILL;
 	private PDFont font;
 	private boolean overprintingFlagStroke = false;
@@ -63,6 +65,22 @@ public class GraphicState implements Cloneable {
 
 	public void setStrokeColorSpace(PDColorSpace strokeColorSpace) {
 		this.strokeColorSpace = strokeColorSpace;
+	}
+
+	public PDColorSpace getFillLastPatternUnderlyingColorSpace() {
+		return fillLastPatternUnderlyingColorSpace;
+	}
+
+	public void setFillLastPatternUnderlyingColorSpace(PDColorSpace fillLastPatternUnderlyingColorSpace) {
+		this.fillLastPatternUnderlyingColorSpace = fillLastPatternUnderlyingColorSpace;
+	}
+
+	public PDColorSpace getStrokeLastPatternUnderlyingColorSpace() {
+		return strokeLastPatternUnderlyingColorSpace;
+	}
+
+	public void setStrokeLastPatternUnderlyingColorSpace(PDColorSpace strokeLastPatternUnderlyingColorSpace) {
+		this.strokeLastPatternUnderlyingColorSpace = strokeLastPatternUnderlyingColorSpace;
 	}
 
 	public RenderingMode getRenderingMode() {
@@ -125,6 +143,8 @@ public class GraphicState implements Cloneable {
 	public void copyProperties(GraphicState graphicState) {
 		this.fillColorSpace = graphicState.getFillColorSpace();
 		this.strokeColorSpace = graphicState.getStrokeColorSpace();
+		this.fillLastPatternUnderlyingColorSpace = graphicState.getFillLastPatternUnderlyingColorSpace();
+		this.strokeLastPatternUnderlyingColorSpace = graphicState.getStrokeLastPatternUnderlyingColorSpace();
 		this.renderingMode = graphicState.getRenderingMode();
 		this.font = graphicState.getFont();
 		this.overprintingFlagStroke = graphicState.isOverprintingFlagStroke();
@@ -157,6 +177,8 @@ public class GraphicState implements Cloneable {
 		GraphicState clone = new GraphicState();
 		clone.fillColorSpace = this.fillColorSpace;
 		clone.strokeColorSpace = this.strokeColorSpace;
+		clone.fillLastPatternUnderlyingColorSpace = this.fillLastPatternUnderlyingColorSpace;
+		clone.strokeLastPatternUnderlyingColorSpace = this.strokeLastPatternUnderlyingColorSpace;
 		clone.renderingMode = this.renderingMode;
 		clone.font = this.font;
 		clone.overprintingFlagStroke = this.overprintingFlagStroke;

--- a/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/OperatorParser.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/OperatorParser.java
@@ -69,6 +69,7 @@ import org.verapdf.pd.colors.PDColorSpace;
 import org.verapdf.pd.colors.PDDeviceCMYK;
 import org.verapdf.pd.colors.PDDeviceGray;
 import org.verapdf.pd.colors.PDDeviceRGB;
+import org.verapdf.pd.patterns.PDPattern;
 import org.verapdf.pd.structure.StructureElementAccessObject;
 import org.verapdf.pdfa.flavours.PDFAFlavour;
 
@@ -520,10 +521,14 @@ class OperatorParser {
 												 PDResourcesHandler resourcesHandler, boolean stroke) {
 		PDColorSpace colorSpace = stroke ? graphicState.getStrokeColorSpace() : graphicState.getFillColorSpace();
 		if (colorSpace != null && ASAtom.PATTERN == colorSpace.getType()) {
+			PDColorSpace underlyingColorSpace = ((PDPattern) colorSpace).getUnderlyingColorSpace();
+			PDPattern pattern = resourcesHandler.getPattern(getLastCOSName(arguments));
 			if (stroke) {
-				graphicState.setStrokeColorSpace(resourcesHandler.getPattern(getLastCOSName(arguments)));
+				graphicState.setStrokeLastPatternUnderlyingColorSpace(underlyingColorSpace);
+				graphicState.setStrokeColorSpace(pattern);
 			} else {
-				graphicState.setFillColorSpace(resourcesHandler.getPattern(getLastCOSName(arguments)));
+				graphicState.setFillLastPatternUnderlyingColorSpace(underlyingColorSpace);
+				graphicState.setFillColorSpace(pattern);
 			}
 		}
 	}

--- a/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/OperatorParser.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/OperatorParser.java
@@ -136,7 +136,9 @@ class OperatorParser {
 				processedOperators.add(new GFOp_M_miter_limit(arguments));
 				break;
 			case Operators.RI:
-				processedOperators.add(new GFOp_ri(arguments));
+				if (this.graphicState.isProcessColorOperators()) {
+					processedOperators.add(new GFOp_ri(arguments));
+				}
 				break;
 			case Operators.W_LINE_WIDTH:
 				processedOperators.add(new GFOp_w_line_width(arguments));
@@ -181,64 +183,82 @@ class OperatorParser {
 
 			// COLOR
 			case Operators.G_STROKE: {
-				processColorSpace(this.graphicState, resourcesHandler, PDDeviceGray.INSTANCE,
-						ASAtom.DEVICEGRAY, true);
-				processedOperators.add(getStrokeColorOperator(arguments, resourcesHandler, graphicState));
+				if (this.graphicState.isProcessColorOperators()) {
+					processColorSpace(this.graphicState, resourcesHandler, PDDeviceGray.INSTANCE,
+					                  ASAtom.DEVICEGRAY, true);
+					processedOperators.add(getStrokeColorOperator(arguments, resourcesHandler, graphicState));
+				}
 				break;
 			}
 			case Operators.G_FILL: {
-				processColorSpace(this.graphicState, resourcesHandler, PDDeviceGray.INSTANCE,
-						ASAtom.DEVICEGRAY, false);
-				processedOperators.add(getFillColorOperator(arguments, resourcesHandler, graphicState));
+				if (this.graphicState.isProcessColorOperators()) {
+					processColorSpace(this.graphicState, resourcesHandler, PDDeviceGray.INSTANCE,
+					                  ASAtom.DEVICEGRAY, false);
+					processedOperators.add(getFillColorOperator(arguments, resourcesHandler, graphicState));
+				}
 				break;
 			}
 			case Operators.RG_STROKE: {
-				processColorSpace(this.graphicState, resourcesHandler, PDDeviceRGB.INSTANCE,
-						ASAtom.DEVICERGB, true);
-				processedOperators.add(getStrokeColorOperator(arguments, resourcesHandler, graphicState));
+				if (this.graphicState.isProcessColorOperators()) {
+					processColorSpace(this.graphicState, resourcesHandler, PDDeviceRGB.INSTANCE,
+					                  ASAtom.DEVICERGB, true);
+					processedOperators.add(getStrokeColorOperator(arguments, resourcesHandler, graphicState));
+				}
 				break;
 			}
 			case Operators.RG_FILL: {
-				processColorSpace(this.graphicState, resourcesHandler, PDDeviceRGB.INSTANCE,
-						ASAtom.DEVICERGB, false);
-				processedOperators.add(getFillColorOperator(arguments, resourcesHandler, graphicState));
+				if (this.graphicState.isProcessColorOperators()) {
+					processColorSpace(this.graphicState, resourcesHandler, PDDeviceRGB.INSTANCE,
+					                  ASAtom.DEVICERGB, false);
+					processedOperators.add(getFillColorOperator(arguments, resourcesHandler, graphicState));
+				}
 				break;
 			}
 			case Operators.K_STROKE: {
-				processColorSpace(this.graphicState, resourcesHandler, PDDeviceCMYK.INSTANCE,
-						ASAtom.DEVICECMYK, true);
-				processedOperators.add(getStrokeColorOperator(arguments, resourcesHandler, graphicState));
+				if (this.graphicState.isProcessColorOperators()) {
+					processColorSpace(this.graphicState, resourcesHandler, PDDeviceCMYK.INSTANCE,
+					                  ASAtom.DEVICECMYK, true);
+					processedOperators.add(getStrokeColorOperator(arguments, resourcesHandler, graphicState));
+				}
 				break;
 			}
 			case Operators.K_FILL: {
-				processColorSpace(this.graphicState, resourcesHandler, PDDeviceCMYK.INSTANCE,
-						ASAtom.DEVICECMYK, false);
-				processedOperators.add(getFillColorOperator(arguments, resourcesHandler, graphicState));
+				if (this.graphicState.isProcessColorOperators()) {
+					processColorSpace(this.graphicState, resourcesHandler, PDDeviceCMYK.INSTANCE,
+					                  ASAtom.DEVICECMYK, false);
+					processedOperators.add(getFillColorOperator(arguments, resourcesHandler, graphicState));
+				}
 				break;
 			}
 			case Operators.CS_STROKE:
-				this.graphicState.setStrokeColorSpace(resourcesHandler.getColorSpace(getLastCOSName(arguments)));
-				processedOperators.add(getStrokeColorOperator(arguments, resourcesHandler, graphicState));
+				if (this.graphicState.isProcessColorOperators()) {
+					this.graphicState.setStrokeColorSpace(resourcesHandler.getColorSpace(getLastCOSName(arguments)));
+					processedOperators.add(getStrokeColorOperator(arguments, resourcesHandler, graphicState));
+				}
 				break;
 			case Operators.CS_FILL:
-				this.graphicState.setFillColorSpace(resourcesHandler.getColorSpace(getLastCOSName(arguments)));
-				processedOperators.add(getFillColorOperator(arguments, resourcesHandler, graphicState));
+				if (this.graphicState.isProcessColorOperators()) {
+					this.graphicState.setFillColorSpace(resourcesHandler.getColorSpace(getLastCOSName(arguments)));
+					processedOperators.add(getFillColorOperator(arguments, resourcesHandler, graphicState));
+				}
 				break;
 			case Operators.SCN_STROKE:
-				processPatternColorSpace(arguments, this.graphicState, resourcesHandler,
-										this.graphicState.getStrokeColorSpace(), true);
-				processedOperators.add(getStrokeColorOperator(arguments, resourcesHandler, graphicState));
+				if (this.graphicState.isProcessColorOperators()) {
+					processPatternColorSpace(arguments, this.graphicState, resourcesHandler, true);
+					processedOperators.add(getStrokeColorOperator(arguments, resourcesHandler, graphicState));
+				}
 				break;
 			case Operators.SCN_FILL:
-				processPatternColorSpace(arguments, this.graphicState, resourcesHandler,
-						this.graphicState.getFillColorSpace(), false);
-				processedOperators.add(getFillColorOperator(arguments, resourcesHandler, graphicState));
+				if (this.graphicState.isProcessColorOperators()) {
+					processPatternColorSpace(arguments, this.graphicState, resourcesHandler,false);
+					processedOperators.add(getFillColorOperator(arguments, resourcesHandler, graphicState));
+				}
 				break;
 			case Operators.SC_STROKE:
-				processedOperators.add(new GFOpSetColor(arguments));
-				break;
 			case Operators.SC_FILL:
-				processedOperators.add(new GFOpSetColor(arguments));
+				if (this.graphicState.isProcessColorOperators()) {
+					processedOperators.add(new GFOpSetColor(arguments));
+				}
 				break;
 
 			// TEXT OBJECT
@@ -318,6 +338,7 @@ class OperatorParser {
 				break;
 			case Operators.D1:
 				processedOperators.add(new GFOp_d1(arguments));
+				this.graphicState.disableColorOperators();
 				break;
 
 			// INLINE IMAGE
@@ -326,7 +347,7 @@ class OperatorParser {
 						(InlineImageOperator) rawOperator,
 						resourcesHandler,
 						arguments,
-						this.graphicState.getFillColorSpace());
+						this.graphicState);
 				break;
 
 			// COMPABILITY
@@ -413,7 +434,9 @@ class OperatorParser {
 
 			// SHADING
 			case Operators.SH:
-				processedOperators.add(new GFOp_sh(arguments, resourcesHandler.getShading(getLastCOSName(arguments))));
+				if (this.graphicState.isProcessColorOperators()) {
+					processedOperators.add(new GFOp_sh(arguments, resourcesHandler.getShading(getLastCOSName(arguments))));
+				}
 				break;
 
 			// SPECIAL GS
@@ -494,7 +517,8 @@ class OperatorParser {
 	}
 
 	private static void processPatternColorSpace(List<COSBase> arguments, GraphicState graphicState,
-												 PDResourcesHandler resourcesHandler, PDColorSpace colorSpace, boolean stroke) {
+												 PDResourcesHandler resourcesHandler, boolean stroke) {
+		PDColorSpace colorSpace = stroke ? graphicState.getStrokeColorSpace() : graphicState.getFillColorSpace();
 		if (colorSpace != null && ASAtom.PATTERN == colorSpace.getType()) {
 			if (stroke) {
 				graphicState.setStrokeColorSpace(resourcesHandler.getPattern(getLastCOSName(arguments)));
@@ -507,12 +531,15 @@ class OperatorParser {
 	private static void processInlineImage(List<org.verapdf.model.operator.Operator> processedOperators,
 										   InlineImageOperator rawOperator, PDResourcesHandler resourcesHandler,
 										   List<COSBase> arguments,
-										   org.verapdf.pd.colors.PDColorSpace inheritedFillCS) {
-		if (rawOperator.getImageParameters() != null) {
-			arguments.add(rawOperator.getImageParameters());
+										   GraphicState gs) {
+		COSDictionary imageParameters = rawOperator.getImageParameters();
+		if (imageParameters != null
+		    && (gs.isProcessColorOperators() || Boolean.TRUE.equals(imageParameters.getBooleanKey(ASAtom.IM)))) {
+
+			arguments.add(imageParameters);
 			processedOperators.add(new GFOp_BI(new ArrayList<COSBase>()));
 			processedOperators.add(new GFOp_ID(arguments));
-			processedOperators.add(new GFOp_EI(arguments, resourcesHandler, inheritedFillCS));
+			processedOperators.add(new GFOp_EI(arguments, resourcesHandler, gs.getFillColorSpace()));
 		}
 	}
 

--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/patterns/GFPDTilingPattern.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/patterns/GFPDTilingPattern.java
@@ -26,6 +26,7 @@ import org.verapdf.gf.model.impl.pd.util.PDResourcesHandler;
 import org.verapdf.model.baselayer.Object;
 import org.verapdf.model.pdlayer.PDContentStream;
 import org.verapdf.model.pdlayer.PDTilingPattern;
+import org.verapdf.pd.colors.PDColorSpace;
 import org.verapdf.pd.structure.StructureElementAccessObject;
 
 import java.util.ArrayList;
@@ -51,9 +52,19 @@ public class GFPDTilingPattern extends GFPDPattern implements PDTilingPattern {
 			GraphicState inheritedGraphicState) {
 		super(simplePDObject, TILING_PATTERN_TYPE);
 		this.resourcesHandler = resourcesHandler;
-		this.inheritedGraphicState = inheritedGraphicState == null
-		                             ? new GraphicState(resourcesHandler)
-		                             : inheritedGraphicState.getInitialGraphicState();
+		if (inheritedGraphicState == null) {
+			this.inheritedGraphicState = new GraphicState(resourcesHandler);
+		} else {
+			this.inheritedGraphicState = inheritedGraphicState.getInitialGraphicState();
+			PDColorSpace fillUnderlyingCS = inheritedGraphicState.getFillLastPatternUnderlyingColorSpace();
+			if (fillUnderlyingCS != null) {
+				this.inheritedGraphicState.setFillColorSpace(fillUnderlyingCS);
+			}
+			PDColorSpace strokeUnderlyingCS = inheritedGraphicState.getStrokeLastPatternUnderlyingColorSpace();
+			if (strokeUnderlyingCS != null) {
+				this.inheritedGraphicState.setStrokeColorSpace(strokeUnderlyingCS);
+			}
+		}
 		if (simplePDObject.isUncolored()) {
 			this.inheritedGraphicState.disableColorOperators();
 		}
@@ -89,7 +100,7 @@ public class GFPDTilingPattern extends GFPDPattern implements PDTilingPattern {
 		List<PDContentStream> contentStreams = new ArrayList<>(MAX_NUMBER_OF_ELEMENTS);
 		org.verapdf.pd.patterns.PDTilingPattern pattern = (org.verapdf.pd.patterns.PDTilingPattern) this.simplePDObject;
 		GFPDContentStream contentStream = new GFPDContentStream(pattern,
-				this.resourcesHandler, inheritedGraphicState, new StructureElementAccessObject(this.simpleCOSObject));
+		                                                        this.resourcesHandler, inheritedGraphicState, new StructureElementAccessObject(this.simpleCOSObject));
 		this.containsTransparency |= contentStream.isContainsTransparency();
 		contentStreams.add(contentStream);
 		this.contentStreams = contentStreams;

--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/patterns/GFPDTilingPattern.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/patterns/GFPDTilingPattern.java
@@ -51,7 +51,12 @@ public class GFPDTilingPattern extends GFPDPattern implements PDTilingPattern {
 			GraphicState inheritedGraphicState) {
 		super(simplePDObject, TILING_PATTERN_TYPE);
 		this.resourcesHandler = resourcesHandler;
-		this.inheritedGraphicState = inheritedGraphicState == null ? null : inheritedGraphicState.getInitialGraphicState();
+		this.inheritedGraphicState = inheritedGraphicState == null
+		                             ? new GraphicState(resourcesHandler)
+		                             : inheritedGraphicState.getInitialGraphicState();
+		if (simplePDObject.isUncolored()) {
+			this.inheritedGraphicState.disableColorOperators();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
process color operator flag logic, add underlying color space processing for PDPattern
requires https://github.com/veraPDF/veraPDF-parser/pull/373
closes https://github.com/veraPDF/veraPDF-library/issues/984