### PR TITLE
Potential NullPointerException caused by xmp-metadata fixed.

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/GFPDMetadata.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/GFPDMetadata.java
@@ -106,13 +106,15 @@ public class GFPDMetadata extends GFPDObject implements PDMetadata {
                     xmp.add(new AXLMainXMPPackage(metadata, true, flavour));
                 } else if (flavour == null || flavour.getPart() != PDFAFlavour.Specification.ISO_19005_1) {
                     VeraPDFXMPNode mainExtensionNode = null;
-                    try (InputStream mainStream = mainMetadata.getStream()) {
-                        if (mainStream != null) {
-                            VeraPDFMeta mainMeta = VeraPDFMeta.parse(mainStream);
-                            mainExtensionNode = mainMeta.getExtensionSchemasNode();
+                    if (mainMetadata != null) {
+                        try (InputStream mainStream = mainMetadata.getStream()) {
+                            if (mainStream != null) {
+                                VeraPDFMeta mainMeta = VeraPDFMeta.parse(mainStream);
+                                mainExtensionNode = mainMeta.getExtensionSchemasNode();
+                            }
                         }
-                        xmp.add(new AXLXMPPackage(metadata, true, mainExtensionNode, flavour));
                     }
+                    xmp.add(new AXLXMPPackage(metadata, true, mainExtensionNode, flavour));
                 }
             }
         } catch (XMPException | IOException e) {


### PR DESCRIPTION
Fix for a potential NullPointerException, that can occure if the document has xmp-metadata-objects for single pages but does not contain a global xmp-metadata-object at the root-catalog-object within the same document.