### PR TITLE
FIX #885

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/cos/GFCosDocument.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/cos/GFCosDocument.java
@@ -189,10 +189,10 @@ public class GFCosDocument extends GFCosObject implements CosDocument {
 	private static String getTrailerID(COSObject ids) {
 		if (ids != null && ids.getType() == COSObjType.COS_ARRAY) {
 			COSArray idArray = (COSArray) ids.getDirectBase();
-			StringBuilder builder = new StringBuilder();
 			if (idArray.size() != 2) {
-				LOGGER.log(Level.WARNING,"Value of ID is not an array of two byte strings");
+				LOGGER.log(Level.WARNING, "Value of ID is not an array of two byte strings");
 			}
+			StringBuilder builder = new StringBuilder();
 			for (COSObject id : idArray) {
 				if (id.getType() == COSObjType.COS_STRING) {
 					for (byte aByte : ((COSString) id.getDirectBase()).get()) {

--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/cos/GFCosDocument.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/cos/GFCosDocument.java
@@ -190,6 +190,9 @@ public class GFCosDocument extends GFCosObject implements CosDocument {
 		if (ids != null && ids.getType() == COSObjType.COS_ARRAY) {
 			COSArray idArray = (COSArray) ids.getDirectBase();
 			StringBuilder builder = new StringBuilder();
+			if (idArray.size() != 2) {
+				LOGGER.log(Level.WARNING,"Value of ID is not an array of two byte strings");
+			}
 			for (COSObject id : idArray) {
 				if (id.getType() == COSObjType.COS_STRING) {
 					for (byte aByte : ((COSString) id.getDirectBase()).get()) {


### PR DESCRIPTION
Added warning message in case that trailer ID is not an array of two byte strings.
Closes https://github.com/veraPDF/veraPDF-library/issues/885