### PR TITLE
FIX #1050

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/GFPDContentStream.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/GFPDContentStream.java
@@ -90,7 +90,7 @@ public class GFPDContentStream extends GFPDObject implements PDContentStream {
 		} else {
 			try {
 				COSObject contentStream = this.contentStream.getContents();
-				if (!contentStream.empty() && contentStream.getType() == COSObjType.COS_STREAM) {
+				if (contentStream.getType() == COSObjType.COS_STREAM || contentStream.getType() == COSObjType.COS_ARRAY) {
 					COSKey key = contentStream.getObjectKey();
 					if (key != null) {
 						if (StaticContainers.getTransparencyVisitedContentStreams().contains(key)) {


### PR DESCRIPTION
Added check in case that content stream is COSArray.
Integration tests: passed.
Required: https://github.com/veraPDF/veraPDF-parser/pull/393
Closes: veraPDF/veraPDF-library#1050