### PR TITLE
Concurrency fix: no new ThreadLocal

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/containers/StaticContainers.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/containers/StaticContainers.java
@@ -95,7 +95,6 @@ public class StaticContainers {
 	}
 
 	public static void setRoleMapHelper(Map<ASAtom, ASAtom> roleMap) {
-		StaticContainers.roleMapHelper = new ThreadLocal<>();
 		roleMapHelper.set(new TaggedPDFRoleMapHelper(roleMap));
 	}
 

--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/containers/StaticContainers.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/containers/StaticContainers.java
@@ -37,28 +37,28 @@ import java.util.*;
  */
 public class StaticContainers {
 
-	private static ThreadLocal<PDDocument> document = new ThreadLocal<>();
-	private static ThreadLocal<PDFAFlavour> flavour = new ThreadLocal<>();
+	private static final ThreadLocal<PDDocument> document = new ThreadLocal<>();
+	private static final ThreadLocal<PDFAFlavour> flavour = new ThreadLocal<>();
 
 	// TaggedPDF
-	private static ThreadLocal<TaggedPDFRoleMapHelper> roleMapHelper = new ThreadLocal<>();
+	private static final ThreadLocal<TaggedPDFRoleMapHelper> roleMapHelper = new ThreadLocal<>();
 
 	//PBoxPDSeparation
-	private static ThreadLocal<Map<String, List<GFPDSeparation>>> separations = new ThreadLocal<>();
-	private static ThreadLocal<List<String>> inconsistentSeparations = new ThreadLocal<>();
+	private static final ThreadLocal<Map<String, List<GFPDSeparation>>> separations = new ThreadLocal<>();
+	private static final ThreadLocal<List<String>> inconsistentSeparations = new ThreadLocal<>();
 
 	//ColorSpaceFactory
-	private static ThreadLocal<Map<String, PDColorSpace>> cachedColorSpaces = new ThreadLocal<>();
+	private static final ThreadLocal<Map<String, PDColorSpace>> cachedColorSpaces = new ThreadLocal<>();
 
 	//FontFactory
-	private static ThreadLocal<Map<String, PDFont>> cachedFonts = new ThreadLocal<>();
+	private static final ThreadLocal<Map<String, PDFont>> cachedFonts = new ThreadLocal<>();
 
-	private static ThreadLocal<Set<COSKey>> fileSpecificationKeys = new ThreadLocal<>();
+	private static final ThreadLocal<Set<COSKey>> fileSpecificationKeys = new ThreadLocal<>();
 
-	private static ThreadLocal<Stack<COSKey>> transparencyVisitedContentStreams = new ThreadLocal<>();
-	private static ThreadLocal<Boolean> validPDF = new ThreadLocal<>();
+	private static final ThreadLocal<Stack<COSKey>> transparencyVisitedContentStreams = new ThreadLocal<>();
+	private static final ThreadLocal<Boolean> validPDF = new ThreadLocal<>();
 
-	private static ThreadLocal<Map<String, Glyph>> cachedGlyphs = new ThreadLocal<>();
+	private static final ThreadLocal<Map<String, Glyph>> cachedGlyphs = new ThreadLocal<>();
 
 	public static void clearAllContainers() {
 		document.set(null);


### PR DESCRIPTION
Re-initialising a ThreadLocal wipes the state of other threads. 
This means that concurrently validating PDF files fails with a NPE:
```
	Caused by: java.lang.NullPointerException: null
		at org.verapdf.gf.model.impl.pd.GFPDStructElem.getStructureElementStandardType(GFPDStructElem.java:137)
		at org.verapdf.gf.model.impl.pd.gfse.GFSEGeneral.createTypedStructElem(GFSEGeneral.java:38)
		at org.verapdf.gf.model.impl.pd.GFPDStructTreeRoot.parseChildren(GFPDStructTreeRoot.java:121)
		at org.verapdf.gf.model.impl.pd.GFPDStructTreeRoot.getChildren(GFPDStructTreeRoot.java:110)
		at org.verapdf.gf.model.impl.pd.GFPDStructTreeRoot.getLinkedObjects(GFPDStructTreeRoot.java:100)
		at org.verapdf.pdfa.validation.validators.BaseValidator.addAllLinkedObjects(BaseValidator.java:199)
		at org.verapdf.pdfa.validation.validators.BaseValidator.checkNext(BaseValidator.java:166)
		at org.verapdf.pdfa.validation.validators.BaseValidator.validate(BaseValidator.java:117)
		at org.verapdf.pdfa.validation.validators.BaseValidator.validate(BaseValidator.java:93)
		... 63 common frames omitted
```