### PR TITLE
PDF/UA validation. Add method gethasCorrectAlt to GFPDMediaClip

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/actions/GFPDMediaClip.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/actions/GFPDMediaClip.java
@@ -20,6 +20,10 @@
  */
 package org.verapdf.gf.model.impl.pd.actions;
 
+import org.verapdf.as.ASAtom;
+import org.verapdf.cos.COSArray;
+import org.verapdf.cos.COSObjType;
+import org.verapdf.cos.COSObject;
 import org.verapdf.gf.model.impl.pd.GFPDObject;
 import org.verapdf.model.pdlayer.PDMediaClip;
 
@@ -48,6 +52,25 @@ public class GFPDMediaClip extends GFPDObject implements PDMediaClip {
         List<String> list = ((org.verapdf.pd.actions.PDMediaClip)simplePDObject).getAlternateDescription();
         return list.stream()
                 .filter(Objects::nonNull)
-                .collect(Collectors.joining(" "));
+                .collect(Collectors.joining(""));
+    }
+
+    @Override
+    public Boolean gethasCorrectAlt() {
+        COSObject object = simplePDObject.getKey(ASAtom.ALT);
+        if (object.getType() != COSObjType.COS_ARRAY) {
+            return false;
+        }
+        COSArray array = (COSArray)object.getDirectBase();
+        if (array.size() % 2 != 0) {
+            return false;
+        }
+        for (int i = 0; i < array.size(); i++) {
+            COSObject elem = array.at(i);
+            if (elem.getType() != COSObjType.COS_STRING || (i % 2 == 1 && elem.getString().isEmpty())) {
+                return false;
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Required: https://github.com/veraPDF/veraPDF-model/pull/214