### PR TITLE
Use BitSet.length() instead of BitSet.size()

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/font/GFPDCIDFont.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/font/GFPDCIDFont.java
@@ -170,7 +170,7 @@ public class GFPDCIDFont extends GFPDFont implements PDCIDFont {
                         }
                     }
                     // we skip i = 0 which corresponds to .notdef glyph
-                    for (int i = 1; i < bitSet.size(); i++) {
+                    for (int i = 1; i < bitSet.length(); i++) {
                         if (bitSet.get(i) && !cidFont.containsCID(i)) {
                             return Boolean.FALSE;
                         }


### PR DESCRIPTION
The `size()` method on `BitSet` returns the size of the underlying native data structure representing the bit set, which is always rounded up to the nearest multiple of 64. This causes the declared `CIDSet <= font CIDset` subset check to become overly strict if the number of glyphs in the `CIDSet` is not an exact multiple of 64.

This commit changes that call to `BitSet.length()` instead, to use the logical (as opposed to physical) size of the `BitSet` in the computation.

I didn't immediately spot a test module in this repo, but I'm happy to take pointers if those need to be added/modified. Thanks!