### PR TITLE
Use toUnicode with full extracting

### DIFF
--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
@@ -870,7 +870,7 @@ public class ChunkParser {
 				TextState textState = graphicsState.getTextState();
 				org.verapdf.pd.font.PDFont font = textState.getTextFont();
 				int code = font.readCode(inputStream);
-				String value = font.toUnicode(code);
+				String value = font.toUnicode(code, false);
 				double scaling = isVertical ? 1 : textState.getHorizontalScaling();
 				double shift = (textState.getCharacterSpacing() + (code == 32 ? textState.getWordSpacing() : 0)) * scaling;
 				Double width = isVertical ? ((PDCIDFont) font).getVerticalWidth(code) : font.getWidth(code);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode conversion when parsing PDF text, helping ensure glyphs are interpreted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->