### PR TITLE
Fix unbounded recursive embedded-file validation

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/external/GFEmbeddedFile.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/external/GFEmbeddedFile.java
@@ -61,10 +61,18 @@ public class GFEmbeddedFile extends GFExternal implements EmbeddedFile {
 	public static final String EMBEDDED_FILE_TYPE = "EmbeddedFile";
 
 	private final COSStream stream;
+    protected String id;
 
 	public GFEmbeddedFile(COSStream stream) {
 		super(EMBEDDED_FILE_TYPE);
 		this.stream = stream;
+
+        if (stream != null) {
+            COSKey key = stream.getObjectKey();
+            id = key != null ?
+                    key.getNumber() + " " + key.getGeneration() + " obj " + this.getObjectType()
+                    : super.getID();
+        }
 	}
 
 	@Override
@@ -84,6 +92,11 @@ public class GFEmbeddedFile extends GFExternal implements EmbeddedFile {
 	public Boolean getisValidPDFA124() {
 		return isValidPDFA(new HashSet<>(Arrays.asList(PDFAFlavour.PDFA_1_B, PDFAFlavour.PDFA_2_B,  PDFAFlavour.PDFA_4)));
 	}
+
+    @Override
+    public String getID() {
+        return this.id == null ? super.getID() : this.id;
+    }
 	
 	private boolean isValidPDFA(Set<PDFAFlavour> flavours) {
 		if (this.stream == null) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Embedded files now receive a more consistent identifier when their stream information is available.
  * Existing identifier behavior is preserved when no stream-based identifier can be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->