### PR TITLE
Add alternative source for Ascent/Descent for Type3 fonts

### DIFF
--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
@@ -37,6 +37,7 @@ import org.verapdf.pd.colors.PDDeviceGray;
 import org.verapdf.pd.colors.PDDeviceRGB;
 import org.verapdf.pd.font.PDCIDFont;
 import org.verapdf.pd.font.PDFontDescriptor;
+import org.verapdf.pd.font.type3.PDType3Font;
 import org.verapdf.pd.images.PDXForm;
 import org.verapdf.pd.images.PDXObject;
 import org.verapdf.pd.optionalcontent.PDOCMDDictionary;
@@ -886,6 +887,17 @@ public class ChunkParser {
 						LOGGER.log(Level.WARNING, "The glyph can not be mapped to Unicode");
 					}
 				}
+                if (font instanceof PDType3Font) {
+                    double glyphAscent = ((PDType3Font) font).getAscentFromProgram(code);
+                    if (glyphAscent > textPieces.getAscent()) {
+                        textPieces.setAscent(glyphAscent);
+                    }
+                    double glyphDescent = ((PDType3Font) font).getDescentFromProgram(code);
+                    if (glyphDescent < textPieces.getDescent()) {
+                        textPieces.setDescent(glyphDescent);
+                    }
+                }
+
 				textPieces.add(new TextPieces.TextPiece(value, current, current + width));
 				textPieces.shiftCurrent(shift);
 			}
@@ -934,7 +946,7 @@ public class ChunkParser {
 			PDFontDescriptor descriptor = font.getFontDescriptor();
 			String fontNameWithoutSubset = font.getNameWithoutSubset();
 			TextChunk textChunk = new TextChunk(
-				TextChunksHelper.calculateTextBoundingBox(isVertical, textRenderingMatrixBefore, textRenderingMatrixAfter, font, pageNumber),
+				TextChunksHelper.calculateTextBoundingBox(isVertical, textRenderingMatrixBefore, textRenderingMatrixAfter, font, pageNumber, textPieces),
 				textPieces.getValue(), fontNameWithoutSubset, TextChunksHelper.calculateTextSize(textRenderingMatrixAfter),
 				TextChunksHelper.calculateFontWeight(graphicsState.getTextState().getRenderingMode(), font), 
 					descriptor.getItalicAngle(), TextChunksHelper.calculateTextBaseLine(textRenderingMatrixAfter),

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
@@ -888,12 +888,14 @@ public class ChunkParser {
 					}
 				}
                 if (font instanceof PDType3Font) {
-                    double glyphAscent = ((PDType3Font) font).getAscentFromProgram(code);
-                    if (glyphAscent > textPieces.getAscent()) {
+                    Double glyphAscent = ((PDType3Font) font).getAscentFromProgram(code);
+                    if (glyphAscent != null && (textPieces.getAscent() == null ||
+                            glyphAscent > textPieces.getAscent())) {
                         textPieces.setAscent(glyphAscent);
                     }
-                    double glyphDescent = ((PDType3Font) font).getDescentFromProgram(code);
-                    if (glyphDescent < textPieces.getDescent()) {
+                    Double glyphDescent = ((PDType3Font) font).getDescentFromProgram(code);
+                    if (glyphDescent != null && (textPieces.getDescent() == null ||
+                            glyphDescent < textPieces.getDescent())) {
                         textPieces.setDescent(glyphDescent);
                     }
                 }

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextChunksHelper.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextChunksHelper.java
@@ -56,11 +56,11 @@ public class TextChunksHelper {
 		double[] fontBoundingBox = font.getBoundingBox();
 		Double descent = font.getDescent();
 		if (descent == null) {
-            descent = textPieces.getDescent() != 0 ? textPieces.getDescent() : fontBoundingBox[1];
+            descent = textPieces.getDescent() != null ? textPieces.getDescent() : fontBoundingBox[1];
 		}
 		Double ascent = font.getAscent();
 		if (ascent == null) {
-			ascent = textPieces.getAscent() != 0 ? textPieces.getAscent() : fontBoundingBox[3];
+			ascent = textPieces.getAscent() != null ? textPieces.getAscent() : fontBoundingBox[3];
 		}
 		double x1;
 		double x2;

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextChunksHelper.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextChunksHelper.java
@@ -46,21 +46,21 @@ public class TextChunksHelper {
 	}
 
 	protected static BoundingBox calculateTextBoundingBox(boolean isVertical, Matrix textRenderingMatrixBefore, 
-														  Matrix textRenderingMatrixAfter, PDFont font, Integer pageNumber) {
+														  Matrix textRenderingMatrixAfter, PDFont font, Integer pageNumber, TextPieces textPieces) {
 		return isVertical ? TextChunksHelper.calculateTextBoundingBoxV(textRenderingMatrixBefore, textRenderingMatrixAfter, pageNumber)
-				: TextChunksHelper.calculateTextBoundingBoxH(textRenderingMatrixBefore, textRenderingMatrixAfter, font, pageNumber);
+				: TextChunksHelper.calculateTextBoundingBoxH(textRenderingMatrixBefore, textRenderingMatrixAfter, font, pageNumber, textPieces);
 	}
 
 	private static BoundingBox calculateTextBoundingBoxH(Matrix textRenderingMatrixBefore, Matrix textRenderingMatrixAfter, 
-														   PDFont font, Integer pageNumber) {
+														   PDFont font, Integer pageNumber, TextPieces textPieces) {
 		double[] fontBoundingBox = font.getBoundingBox();
 		Double descent = font.getDescent();
 		if (descent == null) {
-			descent = fontBoundingBox[1];
+            descent = textPieces.getDescent() != 0 ? textPieces.getDescent() : fontBoundingBox[1];
 		}
 		Double ascent = font.getAscent();
 		if (ascent == null) {
-			ascent = fontBoundingBox[3];
+			ascent = textPieces.getAscent() != 0 ? textPieces.getAscent() : fontBoundingBox[3];
 		}
 		double x1;
 		double x2;

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextPieces.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextPieces.java
@@ -33,6 +33,8 @@ public class TextPieces {
 	public final boolean isVertical;
 	private int currentIndex;
 	private double current;
+    private double ascent;
+    private double descent;
 
 	TextPieces(boolean isVertical) {
 		this.isVertical = isVertical;
@@ -40,6 +42,8 @@ public class TextPieces {
 		textPieces = new TreeSet<>(isVertical ? new TextPieceComparatorV() : new TextPieceComparatorH());
 		currentIndex = 0;
 		current = 0;
+        ascent = 0;
+        descent = 0;
 	}
 
 	public void add(TextPiece textPiece) {
@@ -132,7 +136,23 @@ public class TextPieces {
 			}
 		}
 		return streamInfos;
-	} 
+	}
+
+    public double getAscent() {
+        return ascent;
+    }
+
+    public void setAscent(double ascent) {
+        this.ascent = ascent;
+    }
+
+    public double getDescent() {
+        return descent;
+    }
+
+    public void setDescent(double descent) {
+        this.descent = descent;
+    }
 
 	public static class TextPiece {
 		private final String value;

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextPieces.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextPieces.java
@@ -33,8 +33,8 @@ public class TextPieces {
 	public final boolean isVertical;
 	private int currentIndex;
 	private double current;
-    private double ascent;
-    private double descent;
+    private Double ascent;
+    private Double descent;
 
 	TextPieces(boolean isVertical) {
 		this.isVertical = isVertical;
@@ -42,8 +42,6 @@ public class TextPieces {
 		textPieces = new TreeSet<>(isVertical ? new TextPieceComparatorV() : new TextPieceComparatorH());
 		currentIndex = 0;
 		current = 0;
-        ascent = 0;
-        descent = 0;
 	}
 
 	public void add(TextPiece textPiece) {
@@ -138,7 +136,7 @@ public class TextPieces {
 		return streamInfos;
 	}
 
-    public double getAscent() {
+    public Double getAscent() {
         return ascent;
     }
 
@@ -146,7 +144,7 @@ public class TextPieces {
         this.ascent = ascent;
     }
 
-    public double getDescent() {
+    public Double getDescent() {
         return descent;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text bounding-box calculations for Type 3 fonts.
  - Enhanced handling of glyph ascent and descent metrics when standard font metrics are unavailable.
  - Improved accuracy of text positioning and layout for affected PDF documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->