### PR TITLE
Fix issue updateSymbolEnds method

### DIFF
--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextChunksHelper.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextChunksHelper.java
@@ -169,7 +169,8 @@ public class TextChunksHelper {
 	}
 
 	protected static void updateSymbolEnds(List<Double> symbolEnds, double shift, double left, int length) {
-		if (length <= 1) {
+		if (length == 0) return;
+        if (length == 1) {
 			symbolEnds.add(left + shift);
 		} else {
 			double newShift = shift / length;


### PR DESCRIPTION
Issue was caused by adding of element to symbolEnds even if length of text value was 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of zero-length text segments to prevent unintended endpoint changes.
  * Preserved existing endpoint behavior for single-character and longer text segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->