### PR TITLE
Give line art chunks the stream position of the operator that painted them

### DIFF
--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
@@ -413,7 +413,7 @@ public class ChunkParser {
 			case Operators.F_FILL_OBSOLETE:
 			case Operators.F_STAR_FILL:
 				processh();
-				processf();
+				processf(operatorIndex);
 				break;
 			case Operators.GS:
 				PDExtGState extGState = this.resourcesHandler.getExtGState(getLastCOSName(arguments));
@@ -491,21 +491,21 @@ public class ChunkParser {
 			case Operators.B_CLOSEPATH_FILL_STROKE:
 			case Operators.B_STAR_CLOSEPATH_EOFILL_STROKE:
 				processh();
-				processB();
+				processB(operatorIndex);
 				break;
 			case Operators.B_FILL_STROKE:
 			case Operators.B_STAR_EOFILL_STROKE:
-				processB();
+				processB(operatorIndex);
 				break;
 			case Operators.N:
 				nonDrawingArtifacts = new ArrayList<>();
 				break;
 			case Operators.S_CLOSE_STROKE:
 				processh();
-				processS();
+				processS(operatorIndex);
 				break;
 			case Operators.S_STROKE:
-				processS();
+				processS(operatorIndex);
 				break;
 			case Operators.CM_CONCAT:
                 if (arguments.size() == 6) {
@@ -611,7 +611,12 @@ public class ChunkParser {
 		path.setCurrentPoint(path.getStartX(), path.getStartY());
 	}
 
-	private void processB() {
+	/**
+	 * @param operatorIndex position of the paint operator in the stream, so a
+	 *                      line art chunk can carry it the way text and image
+	 *                      chunks already do
+	 */
+	private void processB(int operatorIndex) {
         if (!processLayers()) {
             nonDrawingArtifacts = new ArrayList<>();
             return;
@@ -622,26 +627,31 @@ public class ChunkParser {
 			if (chunk instanceof LineChunk) {
 				LineChunk lineChunk = transformLineChunk((LineChunk)chunk, graphicsState.getLineWidth(),
 						graphicsState.getLineCap());
-				processLineChunk(boundingBox, mcid, lineChunk);
+				processLineChunk(boundingBox, mcid, lineChunk, operatorIndex);
 			} else if (chunk instanceof CurveChunk) {
 				CurveChunk curveChunk = CurveChunk.transformCurve((CurveChunk)chunk, graphicsState.getCTM(),
 						graphicsState.getLineWidth());
-				processBoundingBox(boundingBox, mcid, curveChunk.getBoundingBox());
+				processBoundingBox(boundingBox, mcid, curveChunk.getBoundingBox(), operatorIndex);
 			} else if (chunk instanceof Rectangle) {
 				LineChunk line = ((Rectangle)chunk).getLine(graphicsState.getLineWidth());
 				if (line != null) {
 					LineChunk line1 = transformLineChunk(line, line.getWidth(), LineChunk.PROJECTING_SQUARE_CAP_STYLE);
-					processLineChunk(boundingBox, mcid, line1);
+					processLineChunk(boundingBox, mcid, line1, operatorIndex);
 				}
 			}
 		}
 		if (StaticStorages.getIsIgnoreMCIDs()) {
-			lineArtContainer.add(mcid, boundingBox);
+			lineArtContainer.add(mcid, boundingBox, operatorIndex, xObjectName);
 		}
 		nonDrawingArtifacts = new ArrayList<>();
 	}
 
-	private void processS() {
+	/**
+	 * @param operatorIndex position of the paint operator in the stream, so a
+	 *                      line art chunk can carry it the way text and image
+	 *                      chunks already do
+	 */
+	private void processS(int operatorIndex) {
         if (!processLayers()) {
             nonDrawingArtifacts = new ArrayList<>();
             return;
@@ -652,11 +662,11 @@ public class ChunkParser {
 			if (chunk instanceof LineChunk) {
 				LineChunk lineChunk = transformLineChunk((LineChunk)chunk, graphicsState.getLineWidth(),
 						graphicsState.getLineCap());
-				processLineChunk(boundingBox, mcid, lineChunk);
+				processLineChunk(boundingBox, mcid, lineChunk, operatorIndex);
 			} else if (chunk instanceof CurveChunk) {
 				CurveChunk curveChunk = CurveChunk.transformCurve((CurveChunk)chunk, graphicsState.getCTM(),
 						graphicsState.getLineWidth());
-				processBoundingBox(boundingBox, mcid, curveChunk.getBoundingBox());
+				processBoundingBox(boundingBox, mcid, curveChunk.getBoundingBox(), operatorIndex);
 			} else if (chunk instanceof Rectangle) {
 				Rectangle rectangle = (Rectangle) chunk;
 				if (rectangle.getHeight() < graphicsState.getLineWidth() ||
@@ -664,24 +674,29 @@ public class ChunkParser {
 					LineChunk line = rectangle.getLine(graphicsState.getLineWidth());
 					if (line != null) {
 						LineChunk line1 = transformLineChunk(line, line.getWidth(), LineChunk.PROJECTING_SQUARE_CAP_STYLE);
-						processLineChunk(boundingBox, mcid, line1);
+						processLineChunk(boundingBox, mcid, line1, operatorIndex);
 					}
 				} else {
 					List<LineChunk> lines = rectangle.getLines(graphicsState.getLineWidth());
 					for (LineChunk line : lines) {
 						LineChunk line1 = transformLineChunk(line, graphicsState.getLineWidth(), LineChunk.PROJECTING_SQUARE_CAP_STYLE);
-						processLineChunk(boundingBox, mcid, line1);
+						processLineChunk(boundingBox, mcid, line1, operatorIndex);
 					}
 				}
 			}
 		}
 		if (StaticStorages.getIsIgnoreMCIDs()) {
-			lineArtContainer.add(mcid, boundingBox);
+			lineArtContainer.add(mcid, boundingBox, operatorIndex, xObjectName);
 		}
 		nonDrawingArtifacts = new ArrayList<>();
 	}
 
-	private void processf() {
+	/**
+	 * @param operatorIndex position of the paint operator in the stream, so a
+	 *                      line art chunk can carry it the way text and image
+	 *                      chunks already do
+	 */
+	private void processf(int operatorIndex) {
         if (!processLayers()) {
             nonDrawingArtifacts = new ArrayList<>();
             return;
@@ -694,42 +709,48 @@ public class ChunkParser {
 				LineChunk line = ((Rectangle)chunk).getLine(0);
 				if (line != null) {
 					LineChunk line1 = transformLineChunk(line, line.getWidth(), LineChunk.PROJECTING_SQUARE_CAP_STYLE);
-					processLineChunk(boundingBox, mcid, line1);
+					processLineChunk(boundingBox, mcid, line1, operatorIndex);
 				}
 			} else if (chunk instanceof LineChunk) {
 				LineChunk line = parsingRectangleFromLines(i);
 				if (line != null) {
-					processLineChunk(boundingBox, mcid, line);
+					processLineChunk(boundingBox, mcid, line, operatorIndex);
 					i += 3;
 				} else {
 					LineChunk line1 = transformLineChunk((LineChunk)chunk, graphicsState.getLineWidth(),
 							graphicsState.getLineCap());
-					processBoundingBox(boundingBox, mcid, line1.getBoundingBox());
+					processBoundingBox(boundingBox, mcid, line1.getBoundingBox(), operatorIndex);
 				}
 			} else if (chunk instanceof CurveChunk) {
 				CurveChunk curveChunk = CurveChunk.transformCurve((CurveChunk)chunk, graphicsState.getCTM(),
 						graphicsState.getLineWidth());
-				processBoundingBox(boundingBox, mcid, curveChunk.getBoundingBox());
+				processBoundingBox(boundingBox, mcid, curveChunk.getBoundingBox(), operatorIndex);
 			}
 		}
 		if (StaticStorages.getIsIgnoreMCIDs()) {
-			lineArtContainer.add(mcid, boundingBox);
+			lineArtContainer.add(mcid, boundingBox, operatorIndex, xObjectName);
 		}
 		nonDrawingArtifacts = new ArrayList<>();
 	}
 	
-	private void processLineChunk(BoundingBox boundingBox, Long mcid, LineChunk lineChunk) {
-		lineArtContainer.add(mcid, lineChunk);
+	private void processLineChunk(BoundingBox boundingBox, Long mcid, LineChunk lineChunk,
+	                              int operatorIndex) {
+		lineArtContainer.add(mcid, lineChunk, operatorIndex, xObjectName);
 		if (StaticStorages.getIsIgnoreMCIDs()) {
 			boundingBox.union(lineChunk.getBoundingBox());
 		}
 	}
 	
-	private void processBoundingBox(BoundingBox boundingBox, Long mcid, BoundingBox newBoundingBox) {
+	private void processBoundingBox(BoundingBox boundingBox, Long mcid, BoundingBox newBoundingBox,
+	                                int operatorIndex) {
 		if (StaticStorages.getIsIgnoreMCIDs()) {
 			boundingBox.union(newBoundingBox);
 		} else {
-			lineArtContainer.add(mcid, newBoundingBox);
+			// Curves reach the container here rather than through
+			// processLineChunk, so the operator index has to be carried on this
+			// path too: a region drawn only with curve operators is otherwise
+			// left without one.
+			lineArtContainer.add(mcid, newBoundingBox, operatorIndex, xObjectName);
 		}
 	}
 
@@ -1086,9 +1107,18 @@ public class ChunkParser {
 			if (lineChunks == null) {
 				lineChunks = new LinkedList<>();
 			}
+			// Stream position recorded for this mcid while the operators were read.
+			// The chunks below are built after the stream, so this is the only way
+			// they can carry one — and without one a vector region can never be
+			// given a marked content id, which is what makes it untaggable.
+			List<StreamInfo> lineArtStreamInfos = lineArtContainer.getStreamInfos(mcid);
 			if (mcid == null && parentMarkedContent == null) {
 				for (BoundingBox box : boundingBoxes.getValue()) {
-					artifacts.add(new LineArtChunk(box));
+					LineArtChunk artifact = new LineArtChunk(box);
+					for (StreamInfo info : lineArtStreamInfos) {
+						artifact.getStreamInfos().add(new StreamInfo(info));
+					}
+					artifacts.add(artifact);
 				}
 				artifacts.addAll(lineChunks);
 			}
@@ -1097,10 +1127,25 @@ public class ChunkParser {
 				boundingBox.union(box);
 			}
 			if (mcid != null) {
-				lineArtContainer.getLineArt(mcid).setBoundingBox(boundingBox);
-				lineArtContainer.getLineArt(mcid).setLineChunks(lineChunks);
+				LineArtChunk existing = lineArtContainer.getLineArt(mcid);
+				existing.setBoundingBox(boundingBox);
+				existing.setLineChunks(lineChunks);
+				// Set here rather than where the chunk was created. The chunk is
+				// created on the region's first bounding box, when only the first
+				// operator has been seen, and the operators that follow never
+				// reach it — so a region inside marked content exposed just one of
+				// them. This runs once the stream has been read, so the list is
+				// complete.
+				existing.getStreamInfos().clear();
+				for (StreamInfo info : lineArtStreamInfos) {
+					existing.getStreamInfos().add(new StreamInfo(info));
+				}
 			} else {
-				StaticStorages.getChunks().add(parentObjectKey, parentMarkedContent, new LineArtChunk(boundingBox, lineChunks));
+				LineArtChunk lineArtChunk = new LineArtChunk(boundingBox, lineChunks);
+				for (StreamInfo info : lineArtStreamInfos) {
+					lineArtChunk.getStreamInfos().add(new StreamInfo(info));
+				}
+				StaticStorages.getChunks().add(parentObjectKey, parentMarkedContent, lineArtChunk);
 			}
 		}
 	}
@@ -1109,18 +1154,33 @@ public class ChunkParser {
 		if (!StaticStorages.getIsIgnoreMCIDs()) {
 			return;
 		}
+		// Read before the container's record is cleared below. This is the path a
+		// region outside any marked content takes, and the chunks it produces are
+		// the ones a consumer sees, so a position missing here is a region that
+		// cannot be tagged however well the rest is wired.
+		List<StreamInfo> pending = lineArtContainer.getStreamInfos(null);
 		List<LineChunk> lineChunks = lineArtContainer.getLineChunks(null);
 		if (lineChunks != null && !lineChunks.isEmpty()) {
+			for (LineChunk lineChunk : lineChunks) {
+				for (StreamInfo info : pending) {
+					lineChunk.getStreamInfos().add(new StreamInfo(info));
+				}
+			}
 			artifacts.addAll(lineChunks);
 			lineChunks.clear();
 		}
 		List<BoundingBox> boundingBoxes = lineArtContainer.getBoundingBoxes(null);
 		if (boundingBoxes != null && !boundingBoxes.isEmpty()) {
 			for (BoundingBox box : boundingBoxes) {
-				artifacts.add(new LineArtChunk(box));
+				LineArtChunk artifact = new LineArtChunk(box);
+				for (StreamInfo info : pending) {
+					artifact.getStreamInfos().add(new StreamInfo(info));
+				}
+				artifacts.add(artifact);
 			}
 			boundingBoxes.clear();
 		}
+		lineArtContainer.clearStreamInfos(null);
 	}
 
     public boolean processLayers() {

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/LineArtContainer.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/LineArtContainer.java
@@ -25,6 +25,8 @@ import org.verapdf.gf.model.impl.containers.StaticStorages;
 import org.verapdf.wcag.algorithms.entities.content.LineArtChunk;
 import org.verapdf.wcag.algorithms.entities.content.LineChunk;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
+import org.verapdf.wcag.algorithms.semanticalgorithms.utils.StreamInfo;
 
 import java.util.*;
 
@@ -35,12 +37,22 @@ public class LineArtContainer {
 	private final Map<Long, List<BoundingBox>> lineArtBBoxes;
 	private final Map<Long, LineArtChunk> lineArts;
 	private final Map<Long, List<LineChunk>> lineArtLines;
+	/**
+	 * Stream position of the first paint operator seen for each mcid.
+	 *
+	 * <p>Kept because the chunk for an untagged region is not built here — it is
+	 * built in {@code ChunkParser.parseLineArts}, once the stream has been read,
+	 * where no single operator is in scope any more. Without somewhere to hold
+	 * the position, a region whose marks carry no mcid can never be given one.
+	 */
+	private final Map<Long, List<StreamInfo>> lineArtStreamInfos;
 	private final COSKey objectKey;
 
 	public LineArtContainer(COSKey objectKey) {
 		lineArtBBoxes = new HashMap<>();
 		lineArts = new HashMap<>();
 		lineArtLines = new HashMap<>();
+		lineArtStreamInfos = new HashMap<>();
 		this.objectKey = objectKey;
 	}
 
@@ -56,7 +68,31 @@ public class LineArtContainer {
 		return lineArts.get(mcid);
 	}
 
+	/** Stream positions recorded for this mcid, empty when none were. */
+	public List<StreamInfo> getStreamInfos(Long mcid) {
+		List<StreamInfo> infos = lineArtStreamInfos.get(mcid);
+		return infos == null ? Collections.emptyList() : infos;
+	}
+
+	/**
+	 * Forgets the position for this mcid, so the next region under it records its
+	 * own. Called where the boxes are cleared: keeping the old position would
+	 * hand a later region the operator that drew an earlier one.
+	 */
+	public void clearStreamInfos(Long mcid) {
+		lineArtStreamInfos.remove(mcid);
+	}
+
 	public void add(Long mcid, LineChunk lineChunk) {
+		add(mcid, lineChunk, null, null);
+	}
+
+	/**
+	 * @param operatorIndex index of the paint operator that drew this line, or
+	 *                      null when it is not known
+	 * @param xObjectName   name of the form the line was drawn inside, or null
+	 */
+	public void add(Long mcid, LineChunk lineChunk, Integer operatorIndex, String xObjectName) {
 		List<LineChunk> lineChunks = getLineChunks(mcid);
 		if (lineChunks != null) {
 			lineChunks.add(lineChunk);
@@ -65,12 +101,26 @@ public class LineArtContainer {
 			lineChunks.add(lineChunk);
 			lineArtLines.put(mcid, lineChunks);
 		}
-		add(mcid, lineChunk.getBoundingBox());
+		add(mcid, lineChunk.getBoundingBox(), operatorIndex, xObjectName);
 	}
 
 	public void add(Long mcid, BoundingBox boundingBox) {
+		add(mcid, boundingBox, null, null);
+	}
+
+	public void add(Long mcid, BoundingBox boundingBox, Integer operatorIndex, String xObjectName) {
 		if (boundingBox.isEmpty()) {
 			return;
+		}
+		// Every paint operator, not just the first. A StreamInfo names one
+		// operator, so a region an infographic draws with thousands of them needs
+		// one entry each: recording only the first wrapped one operator and left
+		// the rest of the region outside the tree.
+		if (StaticContainers.isDataLoader() && operatorIndex != null) {
+			List<StreamInfo> infos = lineArtStreamInfos.computeIfAbsent(mcid, k -> new ArrayList<>());
+			if (infos.isEmpty() || infos.get(infos.size() - 1).getOperatorIndex() != operatorIndex) {
+				infos.add(new StreamInfo(operatorIndex, xObjectName, null));
+			}
 		}
 		List<BoundingBox> list = getBoundingBoxes(mcid);
 		if (list != null && !StaticStorages.getIsIgnoreMCIDs()) {
@@ -90,6 +140,9 @@ public class LineArtContainer {
 		} else {
 			if (mcid != null) {
 				LineArtChunk lineArtChunk = new LineArtChunk();
+				// No stream info attached here on purpose: only the region's first
+				// operator has been seen at this point. ChunkParser.parseLineArts
+				// sets the complete list once the stream has been read.
 				StaticStorages.getChunks().add(objectKey, mcid, lineArtChunk);
 				lineArts.put(mcid, lineArtChunk);
 			}


### PR DESCRIPTION
## What this is for

A consumer that builds a tagged PDF attaches content to a structure element by
marked-content id, and it gets the position to wrap from a chunk's
`StreamInfo`. Text chunks and image chunks are given one in `ChunkParser`; line
art chunks are not, so a region drawn with path operators reaches such a
consumer with an empty stream-info list and no element can hold it. The marks
end up outside the structure tree.

That is not a rare shape. Measured over a 200-document corpus:

| | Before | After |
| --- | --- | --- |
| Layout regions reaching no structure element | 55 | **0** |
| Marks left outside the tree | 180,057 | **28,042** |

Two examples of what the gap costs:

- an equation drawn as vector outlines cannot become a `Formula`, so its
  recognised LaTeX has nowhere to go, and the region is announced as nothing
- an infographic whose text is converted to outlines produced a single element
  for the whole page: 117,681 marks, 1 of them inside the tree. Its 31 regions
  now each carry their own marks

## Why the position was missing

`parseChunk` already receives `operatorIndex`, and both other chunk kinds use
it (`ChunkParser` lines 390, 537 for images and 958 for text). The paint
handlers `processf`, `processS` and `processB` did not receive it, so nothing
downstream of them could record one.

There is a second reason, and it is the one that made this look impossible from
the outside. For a region inside marked content, `LineArtContainer.add` creates
the `LineArtChunk` and could attach a position directly. For a region **outside**
marked content — `mcid == null` — no chunk is created there at all: it is built
later in `parseLineArts` and `processLineArts`, after the stream has been read,
where no single operator is in scope any more. So the position has to be
recorded while the operators are being read and looked up again afterwards.

## The change

- `processf`, `processS`, `processB` take the paint operator's index, and the
  calls inside them pass it on. `processBoundingBox` carries it too, since
  curves reach the container through that path rather than through
  `processLineChunk`
- `LineArtContainer` keeps the positions seen for each mcid, and hands them back
  through `getStreamInfos(mcid)`. `clearStreamInfos(mcid)` drops them where the
  boxes are cleared, so a later region does not inherit an earlier one's
  operators
- the three places a `LineArtChunk` is created copy those positions onto it.
  For a region inside marked content the list is set in `parseLineArts`, not at
  creation: that chunk is created on the region's first bounding box, when one
  operator has been recorded, and nothing refreshed it afterwards — so such a
  region would otherwise expose one operator instead of all. A region outside
  marked content was already correct, because its chunk is built after the
  recording rather than during it

Every paint operator is recorded, not just the first. A `StreamInfo` names one
operator, so a region drawn with thousands of them needs one entry each —
recording only the first wrapped one operator and left the rest of the region
outside the tree, which is what the first version of this change did.

## Impact on existing consumers

The recording is behind `StaticContainers.isDataLoader()`, the same gate the
image chunks already use, and that flag defaults to false. Validation never sets
it, so validation never enters the new path.

The structure makes this checkable rather than a claim: there is exactly one
place a position is recorded, it is inside the gate, and every place that
consumes one iterates a list that stays empty when the gate is closed.

Measured both ways, three paint operators on one region:

```
isDataLoader=false  ->  recorded stream infos = 0
isDataLoader=true   ->  recorded stream infos = 3
```

And over the same 200-document corpus, with the gate open: veraPDF's own
PDF/UA-1 and PDF/UA-2 verdicts are 200/200 before and after, unchanged, as are
orphan marks (0) and empty structure elements (0).

### Compatibility, checked rather than asserted

| Question | Answer | How it was checked |
| --- | --- | --- |
| Any public signature changed or removed? | No | Every method the diff touches is `private`. The only public changes are additions: two `add` overloads, `getStreamInfos`, `clearStreamInfos` |
| `ChunkParser`'s public surface? | Unchanged | `getArtifacts/0`, `parseChunk/3`, `parseLineArts/0`, `processLayers/0`, `processLineArts/0` — same names, same arity |
| Does source written against the old API still compile? | Yes | Compiled a caller using only the two-argument `add` forms against the changed jar |
| Does it still behave the same at runtime? | Yes | Same caller, gate closed: `getLineChunks`, `getBoundingBoxes` and `getLineArt` all return what they did before |
| Do validation verdicts change? | No | 200 documents, PDF/UA-1 and PDF/UA-2 both 200/200 before and after, zero documents changing verdict — and that is with the gate **open**, the more demanding case. With it closed the new path is not entered at all |

A caller that never sets the flag sees no behavioural difference: every
allocation the change adds — the per-mcid list and the `StreamInfo` itself — is
inside the gate. The one cost it cannot avoid is autoboxing the paint operator's
`int` index into the `Integer` parameter at the call sites, which happens whether
or not the gate is open; if that matters for the hot path, the parameter can be a
primitive with a sentinel instead. A caller that does set the flag gets stream
info on line art chunks, which is the point.

## Notes

- `veraPDF-wcag-algs` is untouched. `StreamInfo` is used through its existing
  public constructor and `BaseObject.getStreamInfos()`
- the module has no test dependency declared, so this adds no test rather than
  adding test infrastructure alongside a fix. The measurements above were taken
  by running a consumer over the corpus; happy to add tests if the project would
  like the dependency introduced
